### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ xx = "2"
 
 [build-dependencies]
 built = { version = "0.8", features = ["chrono"] }
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-profile-only change that reduces debug symbol generation in `dev`; no runtime logic changes, but could slightly impact debugging/stacktrace detail expectations in local builds.
> 
> **Overview**
> Sets Cargo's `dev` profile to `debug = 1` in `Cargo.toml`, reducing the amount of debug info emitted for local development builds (and typically shrinking `target/` size) without affecting release builds or application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac0e397bbd0401eeff0659992a3ff0f39f8b2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->