### PR TITLE
fix(openjdk): crawl jdk 28 ea releases

### DIFF
--- a/src/jvm/vendor/openjdk.rs
+++ b/src/jvm/vendor/openjdk.rs
@@ -27,7 +27,7 @@ impl Vendor for OpenJDK {
 
     fn fetch_data(&self, jvm_data: &mut HashSet<JvmData>) -> eyre::Result<()> {
         let anchors: Vec<AnchorElement> = vec![
-            "archive", "21", "22", "23", "24", "25", "26", "27", "leyden", "loom", "valhalla",
+            "archive", "21", "22", "23", "24", "25", "26", "27", "28", "leyden", "loom", "valhalla",
         ]
         .into_par_iter()
         .flat_map(|version| {


### PR DESCRIPTION
## Summary
- add the JDK 28 page to the OpenJDK crawler
- allow the daily metadata update to publish OpenJDK 28 EA artifacts

## Why
`jdk.java.net` now advertises JDK 28 as early access, and mise's Java e2e test follows that page. The crawler was still limited to OpenJDK pages through 27, so `mise-java.jdx.dev` did not publish `openjdk-28.0.0-ea` metadata.

## Validation
- `cargo test openjdk`
- `cargo fmt --check`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version slug added to an existing crawl list; no auth, data, or behavioral changes beyond including one more upstream page.
> 
> **Overview**
> Extends the OpenJDK vendor crawler so **`jdk.java.net/28/`** is fetched alongside existing version pages (21–27, archive, and project tracks).
> 
> That one-line addition to the anchor list in `fetch_data` lets daily metadata updates discover and publish **OpenJDK 28 early-access** artifacts (e.g. `openjdk-28.0.0-ea`), which were missing while JDK 28 was already advertised on jdk.java.net.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78823ae7690de5af425a9ef362cd71cf571a7448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenJDK 28, enabling the system to fetch and collect data for OpenJDK 28 artifacts from the official JDK repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->