### PR TITLE
fix(db): lower initial pool connection count

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,10 @@
 # Maximum number of connections to the database. Default is 10.
 pool_size = 10
 
+# ROAST_DATABASE_MIN_IDLE
+# Minimum idle database connections. Default is 1.
+min_idle = 1
+
 # ROAST_DATABASE_URL
 # Database connection URL.
 url = "postgres://roast:roast@localhost:5432/roast"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,9 @@ pub struct DatabaseConf {
     /// Database connection pool size. Default: 10
     #[config(env = "ROAST_DATABASE_POOL_SIZE")]
     pub pool_size: Option<u32>,
+    /// Minimum idle database connections. Default: 1
+    #[config(env = "ROAST_DATABASE_MIN_IDLE")]
+    pub min_idle: Option<u32>,
     /// Database connection URL
     #[config(env = "ROAST_DATABASE_URL")]
     pub url: Option<String>,

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -51,8 +51,11 @@ impl ConnectionPool {
                     }
                     let tls_connector = MakeTlsConnector::new(connector.build());
                     let manager = PostgresConnectionManager::new(url.parse().unwrap(), tls_connector);
+                    let pool_size = conf.database.pool_size.unwrap_or(10);
+                    let min_idle = conf.database.min_idle.unwrap_or(1).min(pool_size);
                     let pool = Pool::builder()
-                        .max_size(conf.database.pool_size.unwrap_or(10))
+                        .max_size(pool_size)
+                        .min_idle(Some(min_idle))
                         .max_lifetime(Some(Duration::from_secs(60 * 60)))
                         .build(manager)?;
                     Ok(pool)


### PR DESCRIPTION
## Summary
- add `ROAST_DATABASE_MIN_IDLE` / `database.min_idle`
- default initial idle DB connections to 1 instead of r2d2's implicit max-size default
- keep `database.pool_size` as the max connection count

## Why
The OpenJDK data update failed before crawling or inserting data:

```text
Running `target/debug/roast fetch openjdk`
fetching vendors: ["openjdk"]
Error: timed out waiting for connection
Location: src/db/pool.rs:54:32
```

That line is `Pool::builder().build(manager)`. r2d2 defaults `min_idle` to `max_size`, so startup waits for 10 initial Postgres connections. The update job only needs to prove the DB is reachable before fetching, and the pool can still grow up to `pool_size` later when inserts/exports need it.

## Validation
- `cargo fmt --check`
- `cargo test --all`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small connection-pool tuning with bounded defaults; no auth or data-path changes, though misconfigured `min_idle` could affect concurrency under heavy load.
> 
> **Overview**
> Fixes database pool startup timeouts by **not** pre-opening every connection up to `pool_size` at build time.
> 
> Adds configurable **`database.min_idle`** (`ROAST_DATABASE_MIN_IDLE`, default **1**) alongside existing **`pool_size`**. The r2d2 pool in `src/db/pool.rs` now sets **`min_idle`** explicitly (clamped to `pool_size`) while **`max_size`** stays the cap, so the pool can still grow under load without blocking startup on N simultaneous Postgres handshakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0650cfb7afa1ad17ea05749f00501df17fba14f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->