### PR TITLE
fix(openjdk): add temporary jdk 28 ea alias

### DIFF
--- a/public/api/jvm/ea/linux/x86_64.json
+++ b/public/api/jvm/ea/linux/x86_64.json
@@ -31283,6 +31283,18 @@
     "version": "28.0.0-ea+1"
   },
   {
+    "checksum": "sha256:d9b2b25f13a93424625f129bc9725ded401725e36ac819b9f4951f02bc8fc91c",
+    "created_at": "2026-06-10T20:37:19",
+    "features": [],
+    "file_type": "tar.gz",
+    "image_type": "jdk",
+    "java_version": "28.0.0-ea",
+    "jvm_impl": "hotspot",
+    "url": "https://download.java.net/java/early_access/jdk28/1/GPL/openjdk-28-ea+1_linux-x64_bin.tar.gz",
+    "vendor": "openjdk",
+    "version": "28.0.0-ea"
+  },
+  {
     "checksum": "sha256:d9e53387f1a145a42947ea23e6d3a869fa93c76fec82841b24a9b1ef000acc71",
     "created_at": "2026-06-10T20:37:16",
     "features": [


### PR DESCRIPTION
## Summary
- add a temporary Linux x64 OpenJDK 28 EA alias row for `openjdk-28.0.0-ea`
- keep the existing `openjdk-28.0.0-ea+1` row intact

## Why
The mise 2026.6.2 release e2e currently asks for `java[release_type=ea]@openjdk-28.0.0-ea`, but the published metadata only resolves `openjdk-28.0.0-ea+1`. This tiny data-only PR is intended to unblock the release while the larger #469/#468 data repair sequence is reviewed.

## Notes
This does not repair the `features: [""]` corruption from #467. It is intentionally a temporary unblocker and should be superseded by the clean revert/repair flow.

## Validation
- `jq empty public/api/jvm/ea/linux/x86_64.json`
- `git diff --check`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only metadata addition with no runtime or security logic changes; duplicate row points at an already-published artifact.
> 
> **Overview**
> Adds a **temporary alias row** in `public/api/jvm/ea/linux/x86_64.json` so `openjdk-28.0.0-ea` resolves on Linux x64. The new entry reuses the same checksum and download URL as the existing `28.0.0-ea+1` OpenJDK EA build; only `version` and `java_version` are set to `28.0.0-ea`. The prior `28.0.0-ea+1` row is unchanged.
> 
> Also fixes the file ending so the JSON array closes with a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ee633c374442515ea36932e953def484016000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the available JDK builds with the new OpenJDK 28 early-access release (HotSpot) for Linux x86_64 architecture. Users can now download the tar.gz package variant with included checksums, complete version information, build timestamp metadata, and direct download URLs for secure verification and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->