### PR TITLE
fix(openjdk): restore temporary jdk 28 ea alias

### DIFF
--- a/public/api/jvm/ea/linux/x86_64.json
+++ b/public/api/jvm/ea/linux/x86_64.json
@@ -52079,5 +52079,17 @@
     "url": "https://github.com/SAP/SapMachine/releases/download/sapmachine-13.0.2%2B1/sapmachine-jre-13.0.2-ea.1_linux-x64_bin.tar.gz",
     "vendor": "sapmachine",
     "version": "13.0.2-ea.1"
+  },
+  {
+    "checksum": "sha256:d9b2b25f13a93424625f129bc9725ded401725e36ac819b9f4951f02bc8fc91c",
+    "created_at": "2026-06-10T20:37:19",
+    "features": [],
+    "file_type": "tar.gz",
+    "image_type": "jdk",
+    "java_version": "28.0.0-ea",
+    "jvm_impl": "hotspot",
+    "url": "https://download.java.net/java/early_access/jdk28/1/GPL/openjdk-28-ea+1_linux-x64_bin.tar.gz",
+    "vendor": "openjdk",
+    "version": "28.0.0-ea"
   }
 ]

--- a/public/api/jvm/ea/macosx/aarch64.json
+++ b/public/api/jvm/ea/macosx/aarch64.json
@@ -22372,5 +22372,17 @@
     "url": "https://github.com/bell-sw/Liberica/releases/download/26%2B29-ea/bellsoft-jre26%2B29-ea-macos-aarch64.zip",
     "vendor": "liberica",
     "version": "26.0.0+29-ea"
+  },
+  {
+    "checksum": "sha256:bd5590d508540ee5211ee742cd55a4b060651da545ef6073517f9d6d85c5b9d1",
+    "created_at": "2026-06-10T20:37:19",
+    "features": [],
+    "file_type": "tar.gz",
+    "image_type": "jdk",
+    "java_version": "28.0.0-ea",
+    "jvm_impl": "hotspot",
+    "url": "https://download.java.net/java/early_access/jdk28/1/GPL/openjdk-28-ea+1_macos-aarch64_bin.tar.gz",
+    "vendor": "openjdk",
+    "version": "28.0.0-ea"
   }
 ]


### PR DESCRIPTION
## Summary
- add clean temporary OpenJDK 28 EA alias rows for Linux x64 and macOS arm64
- use `version = 28.0.0-ea` so mise can resolve the exact e2e request
- keep the reverted #469 baseline free of `features: [""]` corruption

## Why
`core/test_java_slow` asks for `java[release_type=ea]@openjdk-28.0.0-ea`. After #469 reverted the bad generated data, that alias disappeared again. This restores the minimal clean rows needed for release CI and local macOS arm64 validation while a durable crawler/resolver fix is handled separately.

## Validation
- `jq empty public/api/jvm/ea/linux/x86_64.json public/api/jvm/ea/macosx/aarch64.json`
- `git diff --check`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static JVM catalog JSON only; no runtime or auth changes, aside from which EA JDK URL mise can install.
> 
> **Overview**
> Restores **OpenJDK 28 EA** catalog entries that were lost when bad generated JVM data was reverted in #469.
> 
> Adds one **JDK** row each to `public/api/jvm/ea/linux/x86_64.json` and `public/api/jvm/ea/macosx/aarch64.json`, with `vendor: openjdk`, `version` / `java_version: 28.0.0-ea`, checksums, and download URLs from `download.java.net`. Rows use empty `features` arrays (no corrupted `features: [""]`). Both files also get a proper closing `]` newline.
> 
> This lets mise resolve `java[release_type=ea]@openjdk-28.0.0-ea` for release CI (`core/test_java_slow`) and local macOS arm64 checks until crawler/resolver work lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541722eacb26f4dfeaf6f715d96a69bcf81847c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added OpenJDK 28.0.0-ea Early Access builds for Linux x86_64 and macOS ARM64 with checksums and download URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->