### PR TITLE
fix(openjdk): preserve ea version aliases

### DIFF
--- a/public/api/jvm/ea/linux/aarch64.json
+++ b/public/api/jvm/ea/linux/aarch64.json
@@ -25159,5 +25159,17 @@
     "url": "https://cdn.azul.com/zulu/bin/zulu19.0.23-ea-jdk19.0.0-ea.7-linux_aarch64.tar.gz",
     "vendor": "zulu",
     "version": "19.0.23.0"
+  },
+  {
+    "checksum": "sha256:642cdb07549c099010edf29631c3ceea1b96000fcd1c15d23598eb99bcb16042",
+    "created_at": "2026-06-10T21:19:20.321295",
+    "features": [],
+    "file_type": "tar.gz",
+    "image_type": "jdk",
+    "java_version": "28.0.0-ea",
+    "jvm_impl": "hotspot",
+    "url": "https://download.java.net/java/early_access/jdk28/1/GPL/openjdk-28-ea+1_linux-aarch64_bin.tar.gz",
+    "vendor": "openjdk",
+    "version": "28.0.0-ea"
   }
 ]

--- a/public/api/jvm/ea/linux/x86_64.json
+++ b/public/api/jvm/ea/linux/x86_64.json
@@ -52091,5 +52091,17 @@
     "url": "https://github.com/SAP/SapMachine/releases/download/sapmachine-13.0.2%2B1/sapmachine-jre-13.0.2-ea.1_linux-x64_bin.tar.gz",
     "vendor": "sapmachine",
     "version": "13.0.2-ea.1"
+  },
+  {
+    "checksum": "sha256:d9b2b25f13a93424625f129bc9725ded401725e36ac819b9f4951f02bc8fc91c",
+    "created_at": "2026-06-10T21:19:20.321295",
+    "features": [],
+    "file_type": "tar.gz",
+    "image_type": "jdk",
+    "java_version": "28.0.0-ea",
+    "jvm_impl": "hotspot",
+    "url": "https://download.java.net/java/early_access/jdk28/1/GPL/openjdk-28-ea+1_linux-x64_bin.tar.gz",
+    "vendor": "openjdk",
+    "version": "28.0.0-ea"
   }
 ]

--- a/public/api/jvm/ea/macosx/aarch64.json
+++ b/public/api/jvm/ea/macosx/aarch64.json
@@ -22384,5 +22384,17 @@
     "url": "https://github.com/bell-sw/Liberica/releases/download/26%2B29-ea/bellsoft-jre26%2B29-ea-macos-aarch64.zip",
     "vendor": "liberica",
     "version": "26.0.0+29-ea"
+  },
+  {
+    "checksum": "sha256:bd5590d508540ee5211ee742cd55a4b060651da545ef6073517f9d6d85c5b9d1",
+    "created_at": "2026-06-10T21:19:20.321295",
+    "features": [],
+    "file_type": "tar.gz",
+    "image_type": "jdk",
+    "java_version": "28.0.0-ea",
+    "jvm_impl": "hotspot",
+    "url": "https://download.java.net/java/early_access/jdk28/1/GPL/openjdk-28-ea+1_macos-aarch64_bin.tar.gz",
+    "vendor": "openjdk",
+    "version": "28.0.0-ea"
   }
 ]

--- a/public/api/jvm/ea/windows/x86_64.json
+++ b/public/api/jvm/ea/windows/x86_64.json
@@ -30219,5 +30219,17 @@
     "url": "https://github.com/bell-sw/Liberica/releases/download/26%2B29-ea/bellsoft-jre26%2B29-ea-windows-amd64.zip",
     "vendor": "liberica",
     "version": "26.0.0+29-ea"
+  },
+  {
+    "checksum": "sha256:4aaad6cb26305877733b973a209216ad1ed529c381dd88c56e3ab87f579f96cc",
+    "created_at": "2026-06-10T21:19:20.321295",
+    "features": [],
+    "file_type": "zip",
+    "image_type": "jdk",
+    "java_version": "28.0.0-ea",
+    "jvm_impl": "hotspot",
+    "url": "https://download.java.net/java/early_access/jdk28/1/GPL/openjdk-28-ea+1_windows-x64_bin.zip",
+    "vendor": "openjdk",
+    "version": "28.0.0-ea"
   }
 ]

--- a/src/cli/export/release_type.rs
+++ b/src/cli/export/release_type.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::{collections::HashMap, fs::File, path::PathBuf};
 
 use eyre::Result;
 use log::info;
@@ -76,7 +76,7 @@ impl ReleaseType {
         for release_type in &release_types {
             for os in &oses {
                 for arch in &archs {
-                    let data = db.export_release_type(release_type, arch, os)?;
+                    let data = with_openjdk_ea_aliases(db.export_release_type(release_type, arch, os)?);
 
                     let export_data = data
                         .into_par_iter()
@@ -103,5 +103,92 @@ impl ReleaseType {
             }
         }
         Ok(())
+    }
+}
+
+fn with_openjdk_ea_aliases(mut data: Vec<JvmData>) -> Vec<JvmData> {
+    let existing = data
+        .iter()
+        .filter(|item| item.vendor == "openjdk")
+        .map(|item| item.version.as_str())
+        .collect::<std::collections::HashSet<&str>>();
+    let mut aliases: HashMap<String, (u64, JvmData)> = HashMap::new();
+
+    for item in &data {
+        if item.vendor != "openjdk" || item.release_type != "ea" {
+            continue;
+        }
+        let Some((alias, build)) = item.version.split_once('+') else {
+            continue;
+        };
+        if !alias.ends_with("-ea") || existing.contains(alias) {
+            continue;
+        }
+        let Ok(build) = build.parse::<u64>() else {
+            continue;
+        };
+
+        let mut alias_item = item.clone();
+        alias_item.java_version = alias.to_string();
+        alias_item.version = alias.to_string();
+        aliases
+            .entry(alias.to_string())
+            .and_modify(|(existing_build, existing_item)| {
+                if build > *existing_build {
+                    *existing_build = build;
+                    *existing_item = alias_item.clone();
+                }
+            })
+            .or_insert((build, alias_item));
+    }
+
+    data.extend(aliases.into_values().map(|(_, item)| item));
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn openjdk(version: &str) -> JvmData {
+        JvmData {
+            architecture: "x86_64".to_string(),
+            file_type: "tar.gz".to_string(),
+            image_type: "jdk".to_string(),
+            java_version: version.to_string(),
+            jvm_impl: "hotspot".to_string(),
+            os: "linux".to_string(),
+            release_type: "ea".to_string(),
+            url: format!("https://example.com/openjdk-{version}.tar.gz"),
+            vendor: "openjdk".to_string(),
+            version: version.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_with_openjdk_ea_aliases() {
+        let data = with_openjdk_ea_aliases(vec![openjdk("28.0.0-ea+1")]);
+        let versions = data.iter().map(|item| item.version.as_str()).collect::<HashSet<_>>();
+
+        assert!(versions.contains("28.0.0-ea+1"));
+        assert!(versions.contains("28.0.0-ea"));
+    }
+
+    #[test]
+    fn test_with_openjdk_ea_aliases_keeps_existing_alias() {
+        let data = with_openjdk_ea_aliases(vec![openjdk("28.0.0-ea+1"), openjdk("28.0.0-ea")]);
+        let aliases = data.iter().filter(|item| item.version == "28.0.0-ea").count();
+
+        assert_eq!(aliases, 1);
+    }
+
+    #[test]
+    fn test_with_openjdk_ea_aliases_uses_highest_build() {
+        let data = with_openjdk_ea_aliases(vec![openjdk("28.0.0-ea+1"), openjdk("28.0.0-ea+2")]);
+        let alias = data.iter().find(|item| item.version == "28.0.0-ea").unwrap();
+
+        assert_eq!(alias.url, "https://example.com/openjdk-28.0.0-ea+2.tar.gz");
     }
 }


### PR DESCRIPTION
## Summary
- preserve buildless OpenJDK EA aliases during release-type export
- add the current `28.0.0-ea` alias rows alongside `28.0.0-ea+1` in checked-in API data
- cover alias generation with focused unit tests

## Why
`jdx/mise` release CI now detects JDK 28 from `jdk.java.net` and installs `java[release_type=ea]@openjdk-28.0.0-ea`. The generated mise-java data only retained `28.0.0-ea+1`, so mise failed with `no metadata found for version openjdk-28.0.0-ea`.

The DB still deduplicates by URL, so aliases cannot live there. This adds compatibility aliases during export instead, where duplicate URLs are valid JSON API rows.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only compatibility layer plus static API catalog updates; no auth or DB schema changes, with behavior covered by unit tests.
> 
> **Overview**
> Fixes mise-style installs that request **buildless** OpenJDK EA versions (e.g. `openjdk-28.0.0-ea`) when the catalog only had build-tagged rows (`28.0.0-ea+1`).
> 
> During **release-type export**, exported rows are passed through **`with_openjdk_ea_aliases`**, which synthesizes extra OpenJDK EA entries by stripping the `+build` suffix from versions like `28.0.0-ea+N`, keeps the **highest build** when several exist, and skips aliases already present. The DB still deduplicates by URL; duplicates are only in the exported JSON API.
> 
> Checked-in **`public/api/jvm/ea/**`** files gain matching **`28.0.0-ea`** JDK rows for linux (aarch64/x86_64), macOS aarch64, and Windows x86_64, with array closing newlines normalized. **Unit tests** cover alias creation, deduplication, and highest-build selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d18973ae547da8e5ec2e73d135fdc88dddef305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->