### PR TITLE
fix(db): support supabase postgres urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ AWS_S3_BUCKET=
 # ROAST_DATABASE_URL is the connection string for the database
 #ROAST_DATABASE_URL=postgres://${ROAST_DB_USR}:${ROAST_DB_PWD}@${ROAST_DB_HOST}:${ROAST_DB_PORT}/${ROAST_DB_NAME}
 # Supabase example:
-#ROAST_DATABASE_URL=postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres?sslmode=require
+#ROAST_DATABASE_URL=postgresql://postgres:PASSWORD@db.PROJECT_REF.supabase.co:5432/postgres?sslmode=require
 
 # ROAST_DATABASE_SSL_MODE is the SSL mode for the database connection
 # Use require for Supabase.

--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,12 @@ AWS_S3_BUCKET=
 
 # ROAST_DATABASE_URL is the connection string for the database
 #ROAST_DATABASE_URL=postgres://${ROAST_DB_USR}:${ROAST_DB_PWD}@${ROAST_DB_HOST}:${ROAST_DB_PORT}/${ROAST_DB_NAME}
+# Supabase example:
+#ROAST_DATABASE_URL=postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres?sslmode=require
 
 # ROAST_DATABASE_SSL_MODE is the SSL mode for the database connection
-#ROAST_DATABASE_SSL_MODE=prefer
+# Use require for Supabase.
+#ROAST_DATABASE_SSL_MODE=require
 
 # ROAST_DATABASE_SSL_CA is the path to the CA certificate for SSL
 #ROAST_DATABASE_SSL_CA=

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -43,6 +43,22 @@ jobs:
             exit 1
           fi
 
+      - name: Validate database URLs
+        run: |
+          if [ -z "$OLD_ROAST_DATABASE_URL" ]; then
+            echo "OLD_ROAST_DATABASE_URL is not configured."
+            exit 1
+          fi
+          if [ -z "$ROAST_DATABASE_URL" ]; then
+            echo "ROAST_DATABASE_URL is not configured."
+            exit 1
+          fi
+          if [[ "$ROAST_DATABASE_URL" == *":6543/"* ]]; then
+            echo "ROAST_DATABASE_URL points at Supabase transaction pooler port 6543."
+            echo "Use the direct connection or session pooler for schema and pg_dump/psql migration work."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -61,11 +77,12 @@ jobs:
 
       - name: Reset target schema
         run: |
-          psql "$ROAST_DATABASE_URL" < sql/schema.sql
+          psql -v ON_ERROR_STOP=1 "$ROAST_DATABASE_URL" < sql/schema.sql
 
       - name: Copy JVM table
         run: |
-          pg_dump "$OLD_ROAST_DATABASE_URL" --data-only --table=JVM --column-inserts | psql "$ROAST_DATABASE_URL"
+          set -o pipefail
+          pg_dump "$OLD_ROAST_DATABASE_URL" --data-only --table=JVM --column-inserts --no-owner --no-privileges | psql -v ON_ERROR_STOP=1 "$ROAST_DATABASE_URL"
 
       - name: Export Data
         run: |

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -37,8 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check confirmation
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
-          if [ "${{ inputs.confirm }}" != "migrate" ]; then
+          if [ "$CONFIRM" != "migrate" ]; then
             echo "Refusing to migrate: confirmation input must be exactly 'migrate'."
             exit 1
           fi
@@ -51,6 +53,10 @@ jobs:
           fi
           if [ -z "$ROAST_DATABASE_URL" ]; then
             echo "ROAST_DATABASE_URL is not configured."
+            exit 1
+          fi
+          if [ "$OLD_ROAST_DATABASE_URL" = "$ROAST_DATABASE_URL" ]; then
+            echo "OLD_ROAST_DATABASE_URL and ROAST_DATABASE_URL must point at different databases."
             exit 1
           fi
           if [[ "$ROAST_DATABASE_URL" == *":6543/"* ]]; then
@@ -77,7 +83,7 @@ jobs:
 
       - name: Reset target schema
         run: |
-          psql -v ON_ERROR_STOP=1 "$ROAST_DATABASE_URL" < sql/schema.sql
+          sed '/^GRANT .* TO roast;$/d' sql/schema.sql | psql -v ON_ERROR_STOP=1 "$ROAST_DATABASE_URL"
 
       - name: Copy JVM table
         run: |

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -1,0 +1,90 @@
+name: "Migrate Database"
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type migrate to reset the target DB and copy JVM rows from OLD_ROAST_DATABASE_URL"
+        required: true
+        default: ""
+      create_pr:
+        description: "Create a pull request with regenerated API data if files change"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: migrate-database
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  OLD_ROAST_DATABASE_URL: ${{ secrets.OLD_ROAST_DATABASE_URL }}
+  RAYON_NUM_THREADS: ${{ vars.RAYON_NUM_THREADS }}
+  ROAST_DATABASE_URL: ${{ secrets.ROAST_DATABASE_URL }}
+  ROAST_DATABASE_SSL_MODE: require
+  RUST_BACKTRACE: 1
+  RUST_LOG: roast=INFO
+  GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "migrate" ]; then
+            echo "Refusing to migrate: confirmation input must be exactly 'migrate'."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          shared-key: "roast"
+
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          experimental: true
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Reset target schema
+        run: |
+          psql "$ROAST_DATABASE_URL" < sql/schema.sql
+
+      - name: Copy JVM table
+        run: |
+          pg_dump "$OLD_ROAST_DATABASE_URL" --data-only --table=JVM --column-inserts | psql "$ROAST_DATABASE_URL"
+
+      - name: Export Data
+        run: |
+          cargo run -- export release-type \
+            --pretty \
+            -o 'alpine-linux,linux,macosx,windows' \
+            -a 'aarch64,arm32,i686,x86_64' \
+            -e 'architecture,checksum_url,filename,os,release_type,size' \
+            -f 'file_type=tar.gz,tar.xz,zip&image_type=jre,jdk&features=!certified,!debug,!fastdebug,!freetype'
+
+      - name: Create Pull Request
+        if: ${{ inputs.create_pr }}
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Export data after database migration
+          title: Export data after database migration
+          base: main
+          labels: automated-pr
+          assignees: ${{ vars.CREATE_PR_ASSIGNEES || 'roele' }}
+          branch: issues/migrate-database-export
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ docker exec -i -u postgres postgres psql -d roast -c "CREATE USER roast WITH PAS
 docker exec -i -u postgres postgres psql -d roast < ./sql/schema.sql
 ```
 
+#### Supabase PostgreSQL
+
+Create a Supabase project, copy its Postgres connection string, and initialize the schema. Prefer the direct
+connection or session pooler connection for update jobs.
+
+```bash
+ROAST_DATABASE_URL="postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres?sslmode=require"
+ROAST_DATABASE_SSL_MODE=require
+psql "$ROAST_DATABASE_URL" < ./sql/schema.sql
+```
+
+Dump and restore the `JVM` table from the old database. The database is an accumulating metadata catalog, so preserving
+existing rows prevents older Java versions from disappearing when upstream vendor APIs stop listing them.
+
+```bash
+pg_dump "$OLD_ROAST_DATABASE_URL" --data-only --table=JVM --column-inserts > jvm.sql
+psql "$ROAST_DATABASE_URL" < jvm.sql
+```
+
+After restoring the table, run the export task and review the generated API diff before publishing.
+
 ## Run
 
 ### Environment variables

--- a/README.md
+++ b/README.md
@@ -46,27 +46,6 @@ docker exec -i -u postgres postgres psql -d roast -c "CREATE USER roast WITH PAS
 docker exec -i -u postgres postgres psql -d roast < ./sql/schema.sql
 ```
 
-#### Supabase PostgreSQL
-
-Create a Supabase project, copy its Postgres connection string, and initialize the schema. Prefer the direct
-connection or session pooler connection for update jobs.
-
-```bash
-ROAST_DATABASE_URL="postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres?sslmode=require"
-ROAST_DATABASE_SSL_MODE=require
-psql "$ROAST_DATABASE_URL" < ./sql/schema.sql
-```
-
-Dump and restore the `JVM` table from the old database. The database is an accumulating metadata catalog, so preserving
-existing rows prevents older Java versions from disappearing when upstream vendor APIs stop listing them.
-
-```bash
-pg_dump "$OLD_ROAST_DATABASE_URL" --data-only --table=JVM --column-inserts > jvm.sql
-psql "$ROAST_DATABASE_URL" < jvm.sql
-```
-
-After restoring the table, run the export task and review the generated API diff before publishing.
-
 ## Run
 
 ### Environment variables

--- a/config.toml
+++ b/config.toml
@@ -4,11 +4,12 @@
 pool_size = 10
 
 # ROAST_DATABASE_URL
-# Database connection URL.
+# Database connection URL. Supabase postgresql:// URLs are also supported.
 url = "postgres://roast:roast@localhost:5432/roast"
 
 # ROAST_DATABASE_SSL_MODE
 # SSL mode for the database connection. One of allow, prefer, require, verify-ca, verify-full. Default is "prefer".
+# Use "require" for Supabase.
 ssl_mode = "prefer"
 
 # ROAST_DATABASE_SSL_CA

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -16,7 +16,7 @@ impl ConnectionPool {
 
         match conf.database.url {
             Some(url) => {
-                if url.starts_with("postgres://") {
+                if is_supported_database_url(&url) {
                     let mut connector = SslConnector::builder(SslMethod::tls())?;
                     match conf
                         .database
@@ -57,10 +57,28 @@ impl ConnectionPool {
                         .build(manager)?;
                     Ok(pool)
                 } else {
-                    Err(eyre::eyre!("unsupported database URL: {}", url))
+                    Err(eyre::eyre!(
+                        "unsupported database URL scheme: expected postgres:// or postgresql://"
+                    ))
                 }
             }
             None => Err(eyre::eyre!("database.url is not configured")),
         }
+    }
+}
+
+fn is_supported_database_url(url: &str) -> bool {
+    url.starts_with("postgres://") || url.starts_with("postgresql://")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_supported_database_url;
+
+    #[test]
+    fn test_is_supported_database_url() {
+        assert!(is_supported_database_url("postgres://user:pass@example.com/db"));
+        assert!(is_supported_database_url("postgresql://user:pass@example.com/db"));
+        assert!(!is_supported_database_url("mysql://user:pass@example.com/db"));
     }
 }


### PR DESCRIPTION
## Summary
- accept both `postgres://` and Supabase-style `postgresql://` database URLs
- add a manual `Migrate Database` workflow to reset Supabase, copy the existing `JVM` table, export API data, and optionally create a PR for export diffs
- keep migration runbook details in this PR instead of the README

## GitHub secrets to update
- `ROAST_DATABASE_URL`: the new Supabase Postgres URL, including SSL, for example:
  ```text
  postgresql://postgres:PASSWORD@db.PROJECT_REF.supabase.co:5432/postgres?sslmode=require
  ```
  Use Supabase's direct connection or session pooler. Do not use the transaction pooler on port `6543` for the migration workflow.
- `OLD_ROAST_DATABASE_URL`: the current/old Postgres URL to copy from. Include SSL parameters in the URL if the old DB requires them.

Existing publish secrets and vars stay unchanged.

## Migration flow
After the secrets are set, run **Actions → Migrate Database → Run workflow** with:
- `confirm`: `migrate`
- `create_pr`: `true`

The workflow will:
1. read the confirmation input through an env var, avoiding direct shell interpolation
2. verify both database URL secrets are present, reject identical source/target URLs, and reject Supabase transaction-pooler URLs
3. reset the target Supabase schema using `sql/schema.sql`, filtering local-only `GRANT ... TO roast` statements
4. copy `JVM` rows from `OLD_ROAST_DATABASE_URL` into `ROAST_DATABASE_URL` with `pg_dump --no-owner --no-privileges`, `set -o pipefail`, and `psql -v ON_ERROR_STOP=1`
5. export release-type API JSON from Supabase
6. open a PR with regenerated API data if anything changes

Preserving the existing DB is intentional: it is an accumulating metadata catalog, and rebuilding from empty can drop older Java versions that upstream vendor APIs no longer list.

## Validation
- `git diff --check`
- `cargo test --all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated database migration workflow available for manual triggering via GitHub Actions.

* **Documentation**
  * Enhanced database URL and SSL configuration guidance for improved Supabase compatibility.
  * Updated environment variable examples with clearer database setup instructions.

* **Bug Fixes**
  * Expanded database URL scheme validation to support both standard and alternative PostgreSQL URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->